### PR TITLE
feat(ALU): adding AND && OR operations

### DIFF
--- a/ULA/ula.vhd
+++ b/ULA/ula.vhd
@@ -25,12 +25,14 @@ entity ALU is
     )
 
 architecture a_ALU of ALU is
-  
+
   signal result: unsigned (16 down to 0);
 
   begin
     result <= (("0" & ent0) + ("0" & ent1)) when sel_op = "00" else  -- Sum operation
               (("0" & ent0) - ("0" & ent1)) when sel_op = "01" else  -- Subtraction operation
+              (("0" & ent0) and ("0" & ent1)) when sel_op = "10" else  -- Comparsion operation (each bit)
+              (("0" & ent0) or ("0" & ent1)) when sel_op = "11" else  -- Active bit checking (Or operation)
               "00000000000000000"
 
     output <= result(15 down to 0);


### PR DESCRIPTION
This pull request enhances the `ALU` architecture in `ULA/ula.vhd` by adding two new logical operations to the ALU's functionality. Specifically, it introduces bitwise AND and OR operations, expanding the ALU's supported operations beyond addition and subtraction.

New ALU operations:

* Added bitwise AND operation for `sel_op = "10"`, enabling per-bit comparison between `ent0` and `ent1`.
* Added bitwise OR operation for `sel_op = "11"`, allowing active bit checking between `ent0` and `ent1`.