### PR TITLE
Feat/program counter

### DIFF
--- a/ProgramCounter/program-counter.vhd
+++ b/ProgramCounter/program-counter.vhd
@@ -1,0 +1,32 @@
+-- Program Counter entity (basically a data register)
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ProgramCounter is
+  port(
+    clock: in std_logic;
+    reset: in std_logic;
+    wr_en: in std_logic;
+    instr_in: in unsigned(14 downto 0); 
+    instr_out: out unsigned(14 downto 0)
+  );
+end entity;
+
+architecture a_ProgramCounter of ProgramCounter is
+  signal s_data: unsigned(14 downto 0);
+
+begin
+  process(clock)  -- Executes in the clock variation
+  begin
+    if rising_edge(clock) then  
+      if reset = '1' then -- Resets the reg
+        s_data <= (others => '0');
+      elsif wr_en = '1' then
+        s_data <= instr_in;  -- Writes in the reg
+      end if;
+    end if;
+  end process;
+  instr_out <= s_data;  -- Output
+end architecture;

--- a/ProgramCounter/sum-entity.vhd
+++ b/ProgramCounter/sum-entity.vhd
@@ -1,0 +1,15 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity SumEntity is
+  port(
+    data_in: in unsigned(14 downto 0); 
+    data_out: out unsigned(14 downto 0)
+  );
+end entity;
+
+architecture a_SumEntity of SumEntity is
+begin  
+  data_out <=  data_in + 1;
+end architecture;


### PR DESCRIPTION
This pull request introduces two new VHDL modules to the `ProgramCounter` directory, implementing a program counter and a simple incrementer. These additions provide the foundational hardware logic for tracking and incrementing instruction addresses in a digital system.

New entity implementations:

* Added the `ProgramCounter` entity and its architecture in `program-counter.vhd`, implementing a clocked register with reset and write enable functionality for a 15-bit instruction address.
* Added the `SumEntity` entity and its architecture in `sum-entity.vhd`, providing a combinational incrementer that outputs the input value plus one for a 15-bit unsigned input.